### PR TITLE
Fix for #3

### DIFF
--- a/src/ffmpeg_decoder.cpp
+++ b/src/ffmpeg_decoder.cpp
@@ -149,12 +149,12 @@ bool FFMPEGDecoder::initDecoder(
     if (hwDevType != AV_HWDEVICE_TYPE_NONE) {
       codecContext_->hw_device_ctx = hw_decoder_init(&hwDeviceContext_, hwDevType, logger_);
       if (codecContext_->hw_device_ctx != NULL) {
-	hwPixFormat_ = find_pix_format(encoding, hwDevType, codec, hwAcc, logger_);
-	// must put in global hash for the callback function
-	pix_format_map[codecContext_] = hwPixFormat_;
-	codecContext_->get_format = get_hw_format;
-      } else { // hardware couldn't be initialized.
-	hwDevType = AV_HWDEVICE_TYPE_NONE;
+        hwPixFormat_ = find_pix_format(encoding, hwDevType, codec, hwAcc, logger_);
+        // must put in global hash for the callback function
+        pix_format_map[codecContext_] = hwPixFormat_;
+        codecContext_->get_format = get_hw_format;
+      } else {  // hardware couldn't be initialized.
+        hwDevType = AV_HWDEVICE_TYPE_NONE;
       }
     }
     codecContext_->width = width;

--- a/src/ffmpeg_encoder.cpp
+++ b/src/ffmpeg_encoder.cpp
@@ -206,13 +206,14 @@ void FFMPEGEncoder::encodeImage(const Image & msg)
   }
 }
 
-void strided_copy(uint8_t *dest, const int stride_dest,
-                 const uint8_t *src, const int stride_src,
-                 const int n, const int length){
-  if (stride_dest == stride_src == length){
+void strided_copy(
+  uint8_t * dest, const int stride_dest, const uint8_t * src, const int stride_src, const int n,
+  const int length)
+{
+  if (stride_dest == stride_src == length) {
     memcpy(dest, src, n * length);
   } else {
-    for(int ii=0; ii < n; ii++){
+    for (int ii = 0; ii < n; ii++) {
       memcpy(dest + stride_dest * ii, src + stride_src * ii, length);
     }
   }
@@ -233,27 +234,19 @@ void FFMPEGEncoder::encodeImage(const cv::Mat & img, const Header & header, cons
   const AVPixelFormat targetFmt = codecContext_->pix_fmt;
   if (targetFmt == AV_PIX_FMT_BGR0) {
     const uint8_t * p = img.data;
-    strided_copy(frame_->data[0], frame_->linesize[0],
-		 p, width,
-		 height, width);
+    strided_copy(frame_->data[0], frame_->linesize[0], p, width, height, width);
   } else if (targetFmt == AV_PIX_FMT_YUV420P) {
     cv::Mat yuv;
     cv::cvtColor(img, yuv, cv::COLOR_BGR2YUV_I420);
     const uint8_t * p = yuv.data;
     // Y
-    strided_copy(
-      frame_->data[0], frame_->linesize[0],
-      p, width,
-      height, width);
+    strided_copy(frame_->data[0], frame_->linesize[0], p, width, height, width);
     // U
     strided_copy(
-      frame_->data[1], frame_->linesize[1],
-      p + width * height, width / 2,
-      height / 2, width / 2);
+      frame_->data[1], frame_->linesize[1], p + width * height, width / 2, height / 2, width / 2);
     // V
     strided_copy(
-      frame_->data[2], frame_->linesize[2],
-      p + width * height + width / 2 * height / 2, width / 2,
+      frame_->data[2], frame_->linesize[2], p + width * height + width / 2 * height / 2, width / 2,
       height / 2, width / 2);
   } else {
     RCLCPP_ERROR_STREAM(logger_, "cannot convert format bgr8 -> " << (int)codecContext_->pix_fmt);

--- a/src/ffmpeg_encoder.cpp
+++ b/src/ffmpeg_encoder.cpp
@@ -210,7 +210,7 @@ void strided_copy(
   uint8_t * dest, const int stride_dest, const uint8_t * src, const int stride_src, const int n,
   const int length)
 {
-  if (stride_dest == stride_src == length) {
+  if ((stride_dest == stride_src) && (stride_src == length)) {
     memcpy(dest, src, n * length);
   } else {
     for (int ii = 0; ii < n; ii++) {

--- a/src/ffmpeg_encoder.cpp
+++ b/src/ffmpeg_encoder.cpp
@@ -206,6 +206,18 @@ void FFMPEGEncoder::encodeImage(const Image & msg)
   }
 }
 
+void strided_copy(uint8_t *dest, const int stride_dest,
+                 const uint8_t *src, const int stride_src,
+                 const int n, const int length){
+  if (stride_dest == stride_src == length){
+    memcpy(dest, src, n * length);
+  } else {
+    for(int ii=0; ii < n; ii++){
+      memcpy(dest + stride_dest * ii, src + stride_src * ii, length);
+    }
+  }
+}
+
 void FFMPEGEncoder::encodeImage(const cv::Mat & img, const Header & header, const rclcpp::Time & t0)
 {
   Lock lock(mutex_);
@@ -216,19 +228,33 @@ void FFMPEGEncoder::encodeImage(const cv::Mat & img, const Header & header, cons
     totalInBytes_ += img.cols * img.rows;  // raw size!
   }
 
-  const uint8_t * p = img.data;
   const int width = img.cols;
   const int height = img.rows;
   const AVPixelFormat targetFmt = codecContext_->pix_fmt;
   if (targetFmt == AV_PIX_FMT_BGR0) {
-    memcpy(frame_->data[0], p, width * height * 3);
+    const uint8_t * p = img.data;
+    strided_copy(frame_->data[0], frame_->linesize[0],
+		 p, width,
+		 height, width);
   } else if (targetFmt == AV_PIX_FMT_YUV420P) {
     cv::Mat yuv;
     cv::cvtColor(img, yuv, cv::COLOR_BGR2YUV_I420);
     const uint8_t * p = yuv.data;
-    memcpy(frame_->data[0], p, width * height);
-    memcpy(frame_->data[1], p + width * height, width * height / 4);
-    memcpy(frame_->data[2], p + width * (height + height / 4), (width * height) / 4);
+    // Y
+    strided_copy(
+      frame_->data[0], frame_->linesize[0],
+      p, width,
+      height, width);
+    // U
+    strided_copy(
+      frame_->data[1], frame_->linesize[1],
+      p + width * height, width / 2,
+      height / 2, width / 2);
+    // V
+    strided_copy(
+      frame_->data[2], frame_->linesize[2],
+      p + width * height + width / 2 * height / 2, width / 2,
+      height / 2, width / 2);
   } else {
     RCLCPP_ERROR_STREAM(logger_, "cannot convert format bgr8 -> " << (int)codecContext_->pix_fmt);
     return;


### PR DESCRIPTION
src/ffmpeg_decoder.cpp:
- check if hwdevice_ctx returns; else default to AV_HWDEVICE_TYPE_NONE.
- use SWS_ACCURATE_RND flag for non-aligned frames.

src/ffmpeg_encoder.cpp:
- use strided copy for non-aligned frame.