### PR TITLE
fix warnings due to libav and image transport deprecation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# the image transport api changed between distros
+if(DEFINED ENV{ROS_DISTRO})
+  if($ENV{ROS_DISTRO} STREQUAL "foxy" OR
+      $ENV{ROS_DISTRO} STREQUAL "galactic")
+    add_definitions(-DUSE_OLD_IMAGE_TRANSPORT_API)
+  endif()
+else()
+  message(ERROR "ROS_DISTRO environment variable is not set!")
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(image_transport REQUIRED)

--- a/include/ffmpeg_image_transport/ffmpeg_encoder.hpp
+++ b/include/ffmpeg_image_transport/ffmpeg_encoder.hpp
@@ -137,7 +137,7 @@ private:
   // libav state
   AVCodecContext * codecContext_{NULL};
   AVFrame * frame_{NULL};
-  AVPacket packet_;
+  AVPacket * packet_;
   int64_t pts_{0};
   PTSMap ptsToStamp_;
   // performance analysis

--- a/include/ffmpeg_image_transport/ffmpeg_subscriber.hpp
+++ b/include/ffmpeg_image_transport/ffmpeg_subscriber.hpp
@@ -39,9 +39,16 @@ protected:
   void subscribeImpl(
     rclcpp::Node * node, const std::string & base_topic, const Callback & callback,
     rmw_qos_profile_t custom_qos) override;
+  void subscribeImpl(
+    rclcpp::Node * node, const std::string & base_topic, const Callback & callback,
+    rmw_qos_profile_t custom_qos, rclcpp::SubscriptionOptions) override
+  {
+    subscribeImpl(node, base_topic, callback, custom_qos);
+  }
 
 private:
   void frameReady(const ImageConstPtr & img, bool /*isKeyFrame*/) const;
+  void initialize(rclcpp::Node * node);
   // -------------- variables
   rclcpp::Logger logger_;
   rclcpp::Node * node_;

--- a/include/ffmpeg_image_transport/ffmpeg_subscriber.hpp
+++ b/include/ffmpeg_image_transport/ffmpeg_subscriber.hpp
@@ -39,12 +39,15 @@ protected:
   void subscribeImpl(
     rclcpp::Node * node, const std::string & base_topic, const Callback & callback,
     rmw_qos_profile_t custom_qos) override;
+
+#ifndef USE_OLD_IMAGE_TRANSPORT_API
   void subscribeImpl(
     rclcpp::Node * node, const std::string & base_topic, const Callback & callback,
     rmw_qos_profile_t custom_qos, rclcpp::SubscriptionOptions) override
   {
     subscribeImpl(node, base_topic, callback, custom_qos);
   }
+#endif
 
 private:
   void frameReady(const ImageConstPtr & img, bool /*isKeyFrame*/) const;

--- a/src/ffmpeg_subscriber.cpp
+++ b/src/ffmpeg_subscriber.cpp
@@ -42,7 +42,14 @@ void FFMPEGSubscriber::subscribeImpl(
   rclcpp::Node * node, const std::string & base_topic, const Callback & callback,
   rmw_qos_profile_t custom_qos)
 {
+  initialize(node);
+  FFMPEGSubscriberPlugin::subscribeImpl(node, base_topic, callback, custom_qos);
+}
+
+void FFMPEGSubscriber::initialize(rclcpp::Node * node)
+{
   node_ = node;
+
   // create parameters from default map
   for (const auto & kv : defaultMap) {
     const std::string key = std::string(nsc) + kv.first;
@@ -53,8 +60,6 @@ void FFMPEGSubscriber::subscribeImpl(
   const std::string ns(nsc);
   const bool mp = get_safe_param<bool>(node_, ns + "measure_performance", false);
   decoder_.setMeasurePerformance(mp);
-
-  FFMPEGSubscriberPlugin::subscribeImpl(node, base_topic, callback, custom_qos);
 }
 
 void FFMPEGSubscriber::internalCallback(const FFMPEGPacketConstPtr & msg, const Callback & user_cb)


### PR DESCRIPTION
Libav no longer likes av_init_packet() which leads to deprecation warnings during compilation under Ubuntu 22.04 (Jammy)
Also, under ROS2 Humble the decoder plugin issues warnings about an unimplemented 5-argument function().
This PR addresses these issues.
