### PR TITLE
Fix invalid conversion from 'const AVCodec*' to 'AVCodec*'

### DIFF
--- a/src/ffmpeg_encoder.cpp
+++ b/src/ffmpeg_encoder.cpp
@@ -94,7 +94,7 @@ bool FFMPEGEncoder::openCodec(int width, int height)
       throw(std::runtime_error("h264_nvmpi must have horiz rez mult of 64"));
     }
     // find codec
-    AVCodec * codec = avcodec_find_encoder_by_name(codecName_.c_str());
+    const AVCodec * codec = avcodec_find_encoder_by_name(codecName_.c_str());
     if (!codec) {
       throw(std::runtime_error("cannot find codec: " + codecName_));
     }


### PR DESCRIPTION
When compiling with libavcodec version 59.37.100 and GCC 12.3.0 I get the following error message:

    src/ffmpeg_encoder.cpp: In member function 'bool ffmpeg_image_transport::FFMPEGEncoder::openCodec(int, int)':
    src/ffmpeg_encoder.cpp:97:51: error: invalid conversion from 'const AVCodec*' to 'AVCodec*' [-fpermissive]

The change in libavcodec that causes this was introduced in https://github.com/FFmpeg/FFmpeg/commit/626535f6a169e2d821b969e0ea77125ba7482113, and appeared first in version 59.0.100.

This commit fixes the error.