### PR TITLE
Update package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake_clang_format</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
   <depend>cv_bridge</depend>


### PR DESCRIPTION
Using rosdep to install dependencies, without the `ament_cmake_clang_format` things fail.